### PR TITLE
Fix microphone permissions and admin layout

### DIFF
--- a/components/AdminConfig.tsx
+++ b/components/AdminConfig.tsx
@@ -6,6 +6,7 @@ import * as ImagePicker from 'expo-image-picker';
 import React, { useEffect, useState } from 'react';
 import {
   Alert,
+  Dimensions,
   Modal,
   Platform,
   ScrollView,
@@ -167,7 +168,11 @@ export default function AdminConfig({ visible, onClose, onSave }: AdminConfigPro
       onRequestClose={onClose}
     >
       <View style={styles.modalOverlay}>
-        <View style={[styles.modalContent, { backgroundColor: colors.card }]}>
+        <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} />
+        <View style={[styles.bottomSheet, { backgroundColor: colors.card }]}>
+          <View style={styles.handle}>
+            <View style={[styles.handleBar, { backgroundColor: colors.text }]} />
+          </View>
           <View style={styles.header}>
             <Text style={[styles.title, { color: colors.text }]}>Admin Configuration</Text>
             <TouchableOpacity style={styles.closeButton} onPress={onClose}>
@@ -307,20 +312,34 @@ export default function AdminConfig({ visible, onClose, onSave }: AdminConfigPro
   );
 }
 
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+const BOTTOM_SHEET_MAX_HEIGHT = SCREEN_HEIGHT * 0.8;
+
 const styles = StyleSheet.create({
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
+    justifyContent: 'flex-end',
   },
-  modalContent: {
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  bottomSheet: {
+    height: BOTTOM_SHEET_MAX_HEIGHT,
     width: '100%',
-    maxWidth: 500,
-    maxHeight: '90%',
-    borderRadius: 16,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
     overflow: 'hidden',
+  },
+  handle: {
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  handleBar: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    opacity: 0.3,
   },
   header: {
     flexDirection: 'row',

--- a/hooks/useNativeVoiceSearch.ts
+++ b/hooks/useNativeVoiceSearch.ts
@@ -1,5 +1,6 @@
 import Voice from '@react-native-voice/voice';
 import * as Haptics from 'expo-haptics';
+import * as Permissions from 'expo-permissions';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 
@@ -47,6 +48,12 @@ export default function useNativeVoiceSearch(
 
   const startListening = useCallback(async () => {
     try {
+      const { status } = await Permissions.askAsync(Permissions.AUDIO_RECORDING);
+      if (status !== 'granted') {
+        Alert.alert('Permission Denied', 'You need to grant microphone access to use voice search.');
+        return;
+      }
+
       await Voice.start('en-IN'); // or 'hi-IN' or 'ar-SA'
       await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     } catch (e) {


### PR DESCRIPTION
This commit addresses two main issues:
1.  The app was not prompting for microphone permissions on iOS and Android. This has been fixed by adding a permission request to the `useNativeVoiceSearch.ts` hook using `expo-permissions`.
2.  The admin configuration popup was too small on mobile devices. This has been fixed by updating the styles in `components/AdminConfig.tsx` to make it a bottom sheet that covers 80% of the screen, improving the user experience on mobile.